### PR TITLE
FIX: Condition that check if channel need to be swapped

### DIFF
--- a/vis/optimizer.py
+++ b/vis/optimizer.py
@@ -93,7 +93,8 @@ class Optimizer(object):
             seed_input = np.expand_dims(seed_input, 0)
 
         # Only possible if channel idx is out of place.
-        if seed_input.shape != desired_shape:
+        if seed_input.shape[-1] != desired_shape[-1] and \
+           seed_input.shape[1] != desired_shape[1]:
             seed_input = np.moveaxis(seed_input, -1, 1)
         return seed_input.astype(K.floatx())
 


### PR DESCRIPTION
### Issue

`seed_input` can have a shape with unknown values, e.g. [1, None, None, 3] in the channel_last case. That causes the fixed condition is `False` and representation changes from channel_last to channel_first and vice-versa.

### Fix

Condition fixed to check only whether the channel is channel_last or channel_first. One of condition always keeps when the same representation.  