### PR TITLE
Fix: InvalidArgumentError: conv2d_1_input_1:0 is both fed and fetched

### DIFF
--- a/tests/vis/test_optimizer.py
+++ b/tests/vis/test_optimizer.py
@@ -1,0 +1,57 @@
+import pytest
+
+import keras.backend as K
+from keras.layers import Dense
+from keras.models import Sequential
+from vis.optimizer import Optimizer
+from vis.losses import Loss
+
+
+class _DummyLoss(Loss):
+    def __init__(self, model):
+        self.name = 'dummy-loss'
+        self.output = model.output
+
+    def build_loss(self):
+        return K.sum(self.output * self.output)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def model_and_losses():
+    model = Sequential([Dense(4, activation='linear', input_shape=(2, ))])
+    losses = [(_DummyLoss(model), 1)]
+    return model, losses
+
+
+def test_wrt_tensor_is_None(model_and_losses):
+    model, losses = model_and_losses
+    opt = Optimizer(model.input, losses, wrt_tensor=None)
+    opt.minimize()
+
+    assert opt.wrt_tensor_is_input_tensor
+    assert opt.wrt_tensor is not None
+    assert opt.wrt_tensor != opt.input_tensor
+
+
+def test_wrt_tensor_is_input_tensor(model_and_losses):
+    model, losses = model_and_losses
+    opt = Optimizer(model.input, losses, wrt_tensor=model.input)
+    opt.minimize()
+
+    assert opt.wrt_tensor_is_input_tensor
+    assert opt.wrt_tensor is not None
+    assert opt.wrt_tensor != opt.input_tensor
+
+
+def test_wrt_tensor_isnt_input_tensor(model_and_losses):
+    model, losses = model_and_losses
+    opt = Optimizer(model.input, losses, wrt_tensor=model.output)
+    opt.minimize()
+
+    assert not opt.wrt_tensor_is_input_tensor
+    assert opt.wrt_tensor is not None
+    assert opt.wrt_tensor != opt.input_tensor
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/vis/optimizer.py
+++ b/vis/optimizer.py
@@ -38,9 +38,10 @@ class Optimizer(object):
         self.input_range = input_range
         self.loss_names = []
         self.loss_functions = []
-        if wrt_tensor is None:
+        self.wrt_tensor = self.input_tensor if wrt_tensor is None else wrt_tensor
+        if self.input_tensor is self.wrt_tensor:
             self.wrt_tensor_is_input_tensor = True
-            self.wrt_tensor = K.identity(input_tensor)
+            self.wrt_tensor = K.identity(self.wrt_tensor)
         else:
             self.wrt_tensor_is_input_tensor = False
 


### PR DESCRIPTION
Hi, I created PullRequest so please refer to it.

**Issue**

If `wrt_tensor` is None, #119 occurs in TensorFlow 1.8.


**Fix**

Create `wrt_tensor` with `keras.backend.identity` to avoid errors.
However, gradient calculation uses input_tensor.