### PR TITLE
Fix #102

### DIFF
--- a/examples/vggnet/attention.ipynb
+++ b/examples/vggnet/attention.ipynb
@@ -383,8 +383,7 @@
     "        grads = visualize_cam(model, layer_idx, filter_indices=20, \n",
     "                              seed_input=img, backprop_modifier=modifier)        \n",
     "        # Lets overlay the heatmap onto original image.    \n",
-    "        jet_heatmap = np.uint8(cm.jet(grads)[..., :3] * 255)\n",
-    "        ax[i].imshow(overlay(jet_heatmap, img))"
+    "        ax[i].imshow(overlay(grads, img), cmap='jet')"
    ]
   },
   {


### PR DESCRIPTION
The *grad-CAM* example did not work, because of `jet_heatmap` having an incorrect shape. This PR fixes the issue.