### PR TITLE
In README.md, Add link to Japanese translation of keras-vis document

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ data format.
 
 ## Quick links
 * Read the documentation at [https://raghakot.github.io/keras-vis](https://raghakot.github.io/keras-vis). 
+   * The Japanese edition is [https://keisen.github.io/keras-vis-docs-ja](https://keisen.github.io/keras-vis-docs-ja).
 * Join the slack [channel](https://keras-vis.herokuapp.com/) for questions/discussions.
 * We are tracking new features/tasks in [waffle.io](https://waffle.io/raghakot/keras-vis). Would love it if you lend us 
 a hand and submit PRs.


### PR DESCRIPTION
We have been writing Japanese translation of [keras-vis document](https://raghakot.github.io/keras-vis) .

* The project is https://github.com/keisen/keras-vis-docs-ja
* The document being written is https://keisen.github.io/keras-vis-docs-ja/

We are looking for reviewers who is able to understand the tech of keras-vis written in Japanese.
Please help us with creating more good document.