### PR TITLE
Fixed TypeError for image value ( #155 and #161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ It is possible to generate an animated gif of optimization progress by leveragin
 activation maximization for 'ouzel' class (output_index: 20).
 
 ```python
+from keras.applications import VGG16
+
 from vis.losses import ActivationMaximization
 from vis.regularizers import TotalVariation, LPNorm
-from vis.modifiers import Jitter
+from vis.input_modifiers import Jitter
 from vis.optimizer import Optimizer
-
 from vis.callbacks import GifGenerator
-from vis.utils.vggnet import VGG16
 
 # Build the VGG16 network with ImageNet weights
 model = VGG16(weights='imagenet', include_top=True)
@@ -151,7 +151,7 @@ losses = [
     (TotalVariation(model.input), 10)
 ]
 opt = Optimizer(model.input, losses)
-opt.minimize(max_iter=500, verbose=True, image_modifiers=[Jitter()], callbacks=[GifGenerator('opt_progress')])
+opt.minimize(max_iter=500, verbose=True, input_modifiers=[Jitter()], callbacks=[GifGenerator('opt_progress')])
 
 ```
 

--- a/vis/callbacks.py
+++ b/vis/callbacks.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import pprint
+import numpy as np
 from .utils import utils
 
 try:
@@ -47,11 +48,15 @@ class Print(OptimizerCallback):
 class GifGenerator(OptimizerCallback):
     """Callback to construct gif of optimized image.
     """
-    def __init__(self, path):
+    def __init__(self, path, input_range=(0, 255)):
         """
         Args:
             path: The file path to save gif.
+            input_range: Specifies the input range as a `(min, max)` tuple.
+                This is used to rescale the `wrt_value` passed to `callback` method
+                to the given range. (Default value=(0, 255))
         """
+        self.input_range = input_range
         _check_imageio()
         if not path.endswith('.gif'):
             path += '.gif'
@@ -59,6 +64,11 @@ class GifGenerator(OptimizerCallback):
 
     def callback(self, i, named_losses, overall_loss, grads, wrt_value):
         img = utils.deprocess_input(wrt_value[0])
+        # If range has integer numbers, cast to 'uint8'
+        if self.input_range is not None and \
+                isinstance(self.input_range[0], int) and \
+                isinstance(self.input_range[1], int):
+            img = np.clip(img, self.input_range[0], self.input_range[1]).astype('uint8')
         img = utils.draw_text(img, "Step {}".format(i + 1))
         self.writer.append_data(img)
 


### PR DESCRIPTION
This PR contain two improvements for fixing #155 and #161 .
The first is to improve a example source code of `Generating animated gif of optimization progress` section in README.md.
The code had implemented with the api of old version  of keras-vis.

The second is to improve `vis.callbacks.GifGenerator` .
The module had been having the problem which #155 and #161 reported.
(i.e., Invalid type of image value)

This closes #155 and closes #161 .